### PR TITLE
Revert "moving XMLInputFactory.properties to Include-Resource, relate…

### DIFF
--- a/orbit/pom.xml
+++ b/orbit/pom.xml
@@ -236,9 +236,9 @@
                             @mail-${javax.mail.version}.jar!/META-INF/javamail.default.address.map,
                             @mail-${javax.mail.version}.jar!/META-INF/javamail.default.providers,
                             @mail-${javax.mail.version}.jar!/META-INF/mailcap,
-                            src/main/resources/XMLInputFactory.properties,
                         </Include-Resource>
                         <Embed-Dependency>geronimo-stax-api_1.0_spec;stax2-api;woodstox-core-asl;inline=true</Embed-Dependency>
+                        <Include-Resource>src/main/resources/XMLInputFactory.properties</Include-Resource>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Reverts wso2/wso2-axiom#23

Having XMLInputFactory.properties with javax.xml.stream.isCoalescing=true property causes errors in file uploading (example: webapp uploading) in carbon server. Hence the revert.

Refer https://wso2.org/jira/browse/CARBON-15386 to keep track of a proper fix.