### PR TITLE
Revert "CARBON-15386 : packaging XMLInputFactory.properties file insi…

### DIFF
--- a/orbit/pom.xml
+++ b/orbit/pom.xml
@@ -238,7 +238,6 @@
                             @mail-${javax.mail.version}.jar!/META-INF/mailcap,
                         </Include-Resource>
                         <Embed-Dependency>geronimo-stax-api_1.0_spec;stax2-api;woodstox-core-asl;inline=true</Embed-Dependency>
-                        <Include-Resource>src/main/resources/XMLInputFactory.properties</Include-Resource>
                     </instructions>
                 </configuration>
             </plugin>

--- a/orbit/src/main/resources/XMLInputFactory.properties
+++ b/orbit/src/main/resources/XMLInputFactory.properties
@@ -1,1 +1,0 @@
-javax.xml.stream.isCoalescing=false


### PR DESCRIPTION
Reverts wso2/wso2-axiom#22

Having XMLInputFactory.properties with javax.xml.stream.isCoalescing=true property causes errors in file uploading (example: webapp uploading) in carbon server. Hence the revert.

Refer https://wso2.org/jira/browse/CARBON-15386 to keep track of a proper fix.