### PR TITLE
Revert "Escape control characters during xml conversions"

### DIFF
--- a/modules/axiom-impl/pom.xml
+++ b/modules/axiom-impl/pom.xml
@@ -50,10 +50,6 @@
             <artifactId>${stax.impl.artifact}</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
         </dependency>

--- a/modules/axiom-impl/src/main/java/org/apache/axiom/om/impl/llom/OMTextImpl.java
+++ b/modules/axiom-impl/src/main/java/org/apache/axiom/om/impl/llom/OMTextImpl.java
@@ -34,7 +34,6 @@ import org.apache.axiom.om.impl.builder.XOPBuilder;
 import org.apache.axiom.util.UIDGenerator;
 import org.apache.axiom.util.base64.Base64Utils;
 import org.apache.axiom.util.stax.XMLStreamWriterUtils;
-import org.apache.commons.text.StringEscapeUtils;
 
 import javax.activation.DataHandler;
 import javax.xml.namespace.QName;
@@ -42,6 +41,8 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 public class OMTextImpl extends OMNodeImpl implements OMText, OMConstants {
     /** Field nameSpace used when serializing Binary stuff as MTOM optimized. */
@@ -73,6 +74,18 @@ public class OMTextImpl extends OMNodeImpl implements OMText, OMConstants {
     private static final String XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance";
     private static final String XSI_PREFIX = "xsi";
     private static final String NIL = "nil";
+
+    /**
+     * Field illegalCharSet contains characters illegal in the XML message and their encoded
+     * values
+     */
+    private static HashMap<String, String> illegalCharSet;
+
+    static {
+        illegalCharSet = new HashMap<>();
+        illegalCharSet.put("\f", "\\\\f");
+        illegalCharSet.put("\b", "\\\\b");
+    }
 
     /**
      * Constructor OMTextImpl.
@@ -475,6 +488,10 @@ public class OMTextImpl extends OMNodeImpl implements OMText, OMConstants {
      * encodes the specified illegal characters in the message
      */
     private String encodeJSONReserved(String message) {
-        return StringEscapeUtils.escapeJava(message);
+        HashMap<String, String> charSet = illegalCharSet;
+        for (Map.Entry<String, String> entry : charSet.entrySet()) {
+            message = message.replaceAll(entry.getKey(), entry.getValue());
+        }
+        return message;
     }
 }

--- a/modules/axiom-parent/pom.xml
+++ b/modules/axiom-parent/pom.xml
@@ -380,11 +380,6 @@
                 <version>1.6</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-                <version>${commons-text.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
                 <version>1.1.1</version>
@@ -472,18 +467,6 @@
             </plugin>
         </plugins>
     </reporting>
-    <repositories>
-        <repository>
-            <id>wso2-nexus</id>
-            <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-        </repository>
-    </repositories>
     <distributionManagement>
         <!--  <repository>
                 <id>wso2-maven2-repository</id>
@@ -511,7 +494,6 @@
         <stax.impl.artifact>wstx-asl</stax.impl.artifact>
         <stax.impl.version>3.2.9</stax.impl.version>
         <failIfNoTests>false</failIfNoTests>
-        <commons-text.version>1.6</commons-text.version>
         <!--
         <stax.impl.groupid>com.sun.xml.stream</stax.impl.groupid>
         <stax.impl.artifact>sjsxp</stax.impl.artifact>


### PR DESCRIPTION
Reverting wso2/wso2-axiom#57 since these changes should be merged only when releasing the axiom.

