### PR TITLE
Make wso2-axiom buildable in Java 11

### DIFF
--- a/modules/axiom-api/pom.xml
+++ b/modules/axiom-api/pom.xml
@@ -242,8 +242,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
+                    <source>1.8</source>
                     <!--This parameter disables doclint-->
                     <doclint>none</doclint>
                 </configuration>

--- a/modules/axiom-c14n/pom.xml
+++ b/modules/axiom-c14n/pom.xml
@@ -66,8 +66,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
+                    <source>1.8</source>
                     <!--This parameter disables doclint-->
                     <doclint>none</doclint>
                 </configuration>

--- a/modules/axiom-dom/pom.xml
+++ b/modules/axiom-dom/pom.xml
@@ -145,8 +145,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
+                    <source>1.8</source>
                     <!--This parameter disables doclint-->
                     <doclint>none</doclint>
                 </configuration>

--- a/modules/axiom-impl/pom.xml
+++ b/modules/axiom-impl/pom.xml
@@ -143,8 +143,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
+                    <source>1.8</source>
                     <!--This parameter disables doclint-->
                     <doclint>none</doclint>
                 </configuration>

--- a/modules/axiom-integration/pom.xml
+++ b/modules/axiom-integration/pom.xml
@@ -100,6 +100,13 @@
             <artifactId>axiom-testutils</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.4.0-b180830.0359</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
## Purpose
Make wso2-axiom buildable in Java 11

## Goals
Make wso2-axiom buildable in Java 11

## Approach
Make wso2-axiom buildable in Java 11

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A