### PR TITLE
Make loadFactoryProperties a public method

### DIFF
--- a/modules/axiom-api/src/main/java/org/apache/axiom/om/util/StAXUtils.java
+++ b/modules/axiom-api/src/main/java/org/apache/axiom/om/util/StAXUtils.java
@@ -450,7 +450,7 @@ public class StAXUtils {
      * @return
      */
     // This has package access since it is used from within anonymous inner classes
-    static Map loadFactoryProperties(String name) {
+    public static Map loadFactoryProperties(String name) {
         ClassLoader cl = getContextClassLoader();
         InputStream in = cl.getResourceAsStream(name);
         if (in == null) {


### PR DESCRIPTION
## Purpose
Make loadFactoryProperties a public method so that other mediation components can use this method for loading property files.
This is a partial fix of https://github.com/wso2/micro-integrator/issues/2487

## Release note
Make loadFactoryProperties a public method so that other mediation components can use this method for loading property files.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes