### PR TITLE
Add changes required to build using JDK 11

### DIFF
--- a/modules/axiom-api/pom.xml
+++ b/modules/axiom-api/pom.xml
@@ -242,7 +242,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.3.2</version>
                 <configuration>
                     <!--This parameter disables doclint-->
                     <doclint>none</doclint>

--- a/modules/axiom-c14n/pom.xml
+++ b/modules/axiom-c14n/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.3.2</version>
                 <configuration>
                     <!--This parameter disables doclint-->
                     <doclint>none</doclint>

--- a/modules/axiom-dom/pom.xml
+++ b/modules/axiom-dom/pom.xml
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.3.2</version>
                 <configuration>
                     <!--This parameter disables doclint-->
                     <doclint>none</doclint>

--- a/modules/axiom-impl/pom.xml
+++ b/modules/axiom-impl/pom.xml
@@ -143,7 +143,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.3.2</version>
                 <configuration>
                     <!--This parameter disables doclint-->
                     <doclint>none</doclint>

--- a/modules/axiom-integration/pom.xml
+++ b/modules/axiom-integration/pom.xml
@@ -65,11 +65,6 @@
             <version>3.1.0</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.2.6</version>
-        </dependency>
-        <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>2.12.0</version>
@@ -88,6 +83,21 @@
             <groupId>net.sf.saxon</groupId>
             <artifactId>saxon-dom</artifactId>
             <version>9.1.0.8</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/modules/axiom-parent/pom.xml
+++ b/modules/axiom-parent/pom.xml
@@ -280,7 +280,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.3.2</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>

--- a/modules/axiom-testsuite/pom.xml
+++ b/modules/axiom-testsuite/pom.xml
@@ -67,7 +67,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.3.2</version>
                     <configuration>
                         <!--This parameter disables doclint-->
                         <doclint>none</doclint>


### PR DESCRIPTION
## Purpose
> This PR address the JDK 11 build issues. Building in JDK 11 is a sub-task for migrating Micro Integrator to JDK 17
Related issue: https://github.com/wso2/api-manager/issues/179