### PR TITLE
Ignore the prefix null check as the prefix can be a null value for some qualified names

### DIFF
--- a/modules/axiom-dom/src/main/java/org/apache/axiom/om/impl/dom/DocumentImpl.java
+++ b/modules/axiom-dom/src/main/java/org/apache/axiom/om/impl/dom/DocumentImpl.java
@@ -170,7 +170,7 @@ public class DocumentImpl extends ParentNode implements Document, OMDocument {
         String localName = DOMUtil.getLocalName(qualifiedName);
         String prefix = DOMUtil.getPrefix(qualifiedName);
 
-        if (!OMConstants.XMLNS_NS_PREFIX.equals(localName)) {
+        if (!OMConstants.XMLNS_NS_PREFIX.equals(localName) && prefix != null) {
             this.checkQName(prefix, localName);
         } else {
             return this.createAttribute(localName);


### PR DESCRIPTION
## Purpose

$subject
Note: This is a front port fix.

According to the java documentation [1], these are the cases where we need to throw the `NAMESPACE_ERR` check.

1. The qualifiedName is a malformed qualified name
2. if the qualifiedName has a prefix and the namespaceURI is null
3. if the qualifiedName has a prefix that is "xml" and the namespaceURI is different from "[ http://www.w3.org/XML/1998/namespace](http://www.w3.org/XML/1998/namespace)"
4. if the qualifiedName or its prefix is "xmlns" and the namespaceURI is different from "http://www.w3.org/2000/xmlns/"
5. if the namespaceURI is "http://www.w3.org/2000/xmlns/" and neither the qualifiedName nor its prefix is "xmlns".

Which means the prefix field of a qualified URL can actually have a null value. In the xmlsec 2.1.7 implementation [2][3] also, xml passes a qualified url without a prefix for the Id attribute (which was the initial problem). Therefore we concluded that the null prefix field will be acceptable in this implementation. 

[1] https://docs.oracle.com/javase/8/docs/api/org/w3c/dom/Document.html#createAttributeNS-java.lang.String-java.lang.String- 
[2] https://github.com/apache/santuario-xml-security-java/blob/b9cc7320000478690287c5e154b728af34934b99/src/main/java/org/apache/xml/security/utils/ElementProxy.java#L564
[3] https://github.com/apache/santuario-xml-security-java/blob/b9cc7320000478690287c5e154b728af34934b99/src/main/java/org/apache/xml/security/utils/Constants.java#L86


## Related Issues
- https://github.com/wso2/product-is/issues/17989
- https://github.com/wso2/product-is/issues/15697

## Related PRs
> List any other related PRs
