### PR TITLE
Wait for the parser to reach end of document when creating SOAP envelopes

### DIFF
--- a/modules/axiom-api/src/main/java/org/apache/axiom/soap/impl/builder/StAXSOAPModelBuilder.java
+++ b/modules/axiom-api/src/main/java/org/apache/axiom/soap/impl/builder/StAXSOAPModelBuilder.java
@@ -200,7 +200,7 @@ public class StAXSOAPModelBuilder extends StAXOMBuilder {
      * @throws OMException
      */
     public SOAPEnvelope getSOAPEnvelope() throws OMException {
-        while ((envelope == null) && !done) {
+        while (!done) {
             next();
         }
         return envelope;


### PR DESCRIPTION
## Purpose

Currently, when the SOAP body’s closing tag is reached by the StAXSOAPModelBuilder, it stops parsing the rest of the data. In cases where the SOAP envelope’s closing tag is decoded into the buffer in the next iteration, the decoder won’t complete the process because the parser has already stopped. Therefore, we need to continue parsing the tokens until we reach the end-of-document token.

Fixes https://github.com/wso2/micro-integrator/issues/3491